### PR TITLE
Fix: Simplify MiiChannelView.css to isolate parsing error

### DIFF
--- a/wii-js-app/src/components/MiiChannelView.css
+++ b/wii-js-app/src/components/MiiChannelView.css
@@ -3,10 +3,7 @@
   /* Assuming WiiMenu provides the context for height (e.g., it's a flex child or has explicit height) */
   /* For now, let's ensure it fills available vertical space if WiiMenu is flex container */
   flex-grow: 1;
-  /* Or, if WiiMenu isn't flex, a specific height like:
-     height: calc(100vh - 40px); /* Assuming 40px is SystemBar height */
-  */
-  background-color: #d0e8f0; /* Cheerful, light sky blue */
+  background-color: #d0e8f0;
   padding: 30px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This commit simplifies the .MiiChannelView CSS rule by removing comments around the 'background-color' property and a preceding multi-line comment block.

This is an attempt to resolve a persistent "Unknown word background-color" parsing error.